### PR TITLE
Remove escaping

### DIFF
--- a/modules/uabb-star-rating/includes/frontend.php
+++ b/modules/uabb-star-rating/includes/frontend.php
@@ -14,7 +14,7 @@ $layout = 0;
 <?php
 if ( 'bottom' === $settings->star_position ) {
 	?>
-	<div class="uabb-rating-title"><?php echo esc_attr( $title ); ?></div>
+	<div class="uabb-rating-title"><?php echo $title; ?></div>
 	<?php
 }
 ?>


### PR DESCRIPTION
### Description
- Remove escaping from the Title input

### Screenshots
- https://share.getcloudapp.com/QwulqDrl

### Types of changes
- Due to escaping, we are not able to pass HTML elements through the input field

### How has this been tested?
I have tested this by myself

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->