### PR TITLE
Added WordPress 5.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** beaver builder, beaver builder free, beaver addons, beaver builder addon, beaver builder add ons, beaver builder lite, beaver builder modules, beaver builder addons, beaver builder extensions, beaver addon, beaver builder plugin, beaver builder wordpress  
 **Requires at least:** 4.6  
-**Tested up to:** 5.6
+**Tested up to:** 5.7
 **Stable tag:** 1.5.0
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
@@ -214,6 +214,9 @@ Yes it is! This plugin comes with .po and .mo files. It is already translated in
 4. /assets/screenshots/4.png
 
 ## Changelog ##
+
+### 1.5.1 ###
+* Improvement: Compatibility with Wordpress 5.7.
 
 ### 1.5.0 ###
 * New: New: Users can now share non-personal usage data to help us test and develop better products.

--- a/modules/flip-box/includes/frontend.js.php
+++ b/modules/flip-box/includes/frontend.js.php
@@ -48,7 +48,7 @@
 
 	});
 
-	jQuery(window).load( function() {
+	jQuery(window).on('load', function() {
 		new UABBFlipBox( args );
 	});
 

--- a/modules/slide-box/js/settings.js
+++ b/modules/slide-box/js/settings.js
@@ -19,7 +19,7 @@ jQuery(document).on( 'click' , '.fl-lightbox-footer span', function(){
     }
 });
 
-jQuery(document).load(function(){
+jQuery(document).on('load', function(){
 	jQuery(".cs-wp-color-picker").cs_wpColorPicker();
 });
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: beaver builder, beaver builder free, beaver addons, beaver builder addon, beaver builder add ons, beaver builder lite, beaver builder modules, beaver builder addons, beaver builder extensions, beaver addon, beaver builder plugin, beaver builder wordpress
 Requires at least: 4.6
-Tested up to: 5.6
+Tested up to: 5.7
 Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -214,6 +214,9 @@ Yes it is! This plugin comes with .po and .mo files. It is already translated in
 4. /assets/screenshots/4.png
 
 == Changelog ==
+
+= 1.5.1 =
+* Improvement: Compatibility with Wordpress 5.7.
 
 = 1.5.0 =
 * New: New: Users can now share non-personal usage data to help us test and develop better products.


### PR DESCRIPTION
### Description
- Jquery migration depreciation with WordPress 5.7

### Screenshots
<!-- if applicable -->

### Types of changes
- Bugfix (non-breaking change which fixes an issue)

### How has this been tested?
- Tested with latest WordPress and WordPress 5.6.2

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->