### PR TITLE
Fixed - Info List - PHP notice error in Info List module when icon size is not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ Yes it is! This plugin comes with .po and .mo files. It is already translated in
 
 ## Changelog ##
 
+### 1.5.4 ###
+* Fixed: Info List - Resolved PHP notice error in Info List module.
+
 ### 1.5.3 ###
 * Fixed: Info List - PHP Fatal error while using with WPML plugin.
 

--- a/modules/info-list/info-list.php
+++ b/modules/info-list/info-list.php
@@ -70,17 +70,17 @@ class UABBInfoList extends FLBuilderModule {
 		$infolist_icon_size = isset( $settings->icon_image_size ) ? $settings->icon_image_size : 75;
 
 		if ( 'circle' == $settings->list_icon_style ) {
-			if ( is_numeric( $settings->icon_image_size ) ) {
-				$infolist_icon_size = $settings->icon_image_size / 2;
+			if ( is_numeric( $infolist_icon_size ) ) {
+				$infolist_icon_size = $infolist_icon_size / 2;
 			}
 		} elseif ( 'square' == $settings->list_icon_style ) {
-			if ( is_numeric( $settings->icon_image_size ) ) {
-				$infolist_icon_size = $settings->icon_image_size / 2;
+			if ( is_numeric( $infolist_icon_size ) ) {
+				$infolist_icon_size = $infolist_icon_size / 2;
 			}
 		} elseif ( 'custom' == $settings->list_icon_style ) {
-			$infolist_icon_size = $settings->icon_image_size;
+			$infolist_icon_size = $infolist_icon_size;
 		} else {
-			$infolist_icon_size = $settings->icon_image_size;
+			$infolist_icon_size = $infolist_icon_size;
 		}
 		$imageicon_array = array(
 

--- a/modules/info-list/info-list.php
+++ b/modules/info-list/info-list.php
@@ -66,7 +66,9 @@ class UABBInfoList extends FLBuilderModule {
 	 * @param object $settings gets the settings for the module.
 	 */
 	public function render_image( $item, $settings ) {
-		$settings->icon_image_size = isset( $settings->icon_image_size ) ? $settings->icon_image_size : 75;
+
+		$infolist_icon_size = isset( $settings->icon_image_size ) ? $settings->icon_image_size : 75;
+
 		if ( 'circle' == $settings->list_icon_style ) {
 			if ( is_numeric( $settings->icon_image_size ) ) {
 				$infolist_icon_size = $settings->icon_image_size / 2;

--- a/modules/info-list/info-list.php
+++ b/modules/info-list/info-list.php
@@ -66,6 +66,7 @@ class UABBInfoList extends FLBuilderModule {
 	 * @param object $settings gets the settings for the module.
 	 */
 	public function render_image( $item, $settings ) {
+		$settings->icon_image_size = isset( $settings->icon_image_size ) ? $settings->icon_image_size : 75;
 		if ( 'circle' == $settings->list_icon_style ) {
 			if ( is_numeric( $settings->icon_image_size ) ) {
 				$infolist_icon_size = $settings->icon_image_size / 2;

--- a/readme.txt
+++ b/readme.txt
@@ -215,6 +215,9 @@ Yes it is! This plugin comes with .po and .mo files. It is already translated in
 
 == Changelog ==
 
+= 1.5.4 =
+* Fixed: Info List - Resolved PHP notice error in Info List module.
+
 = 1.5.3 =
 * Fixed: Info List - PHP Fatal error while using with WPML plugin.
 


### PR DESCRIPTION
###Description
Fixed - Info List - PHP notice error in Info List module when icon size is not specified

`[18-Feb-2022 09:01:10 UTC] PHP Notice:  Undefined variable: infolist_icon_size in /home/runcloud/webapps/websitedemos/wp-content/plugins/ultimate-addons-for-beaver-builder-lite/modules/info-list/info-list.php on line 89`