### PR TITLE
Removed redundant code - function call

### DIFF
--- a/classes/class-uabb-init.php
+++ b/classes/class-uabb-init.php
@@ -53,8 +53,7 @@ class UABB_Init {
 			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 			add_action( 'network_admin_notices', array( $this, 'admin_notices' ) );
 		}
-		// Hook the load_plugin_textdomain function to the init action.
-		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
+
 	}
 	/**
 	 * Function that renders links


### PR DESCRIPTION
This pull request includes a change in the `classes/class-uabb-init.php` file to improve the initialization process by removing an unnecessary action hook.

Codebase simplification:

* [`classes/class-uabb-init.php`](diffhunk://#diff-2b2d15cfe0b0fbfbc128f511be0ddadbe8f094f83e74174c12af2c30d2f288bcL56-R56): Removed the action hook for `load_plugin_textdomain` from the `init` action in the constructor.