### PR TITLE
EPS-1020: Flip Box - Box content bounce on page load in UABB Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Yes, with .po and .mo files and GlotPress support.
 
 ### 1.5.14 ###
 * Improvement: Revised the README content.
+* Fixed: Flip Box - Box content bounce on page load.
 
 ### 1.5.13 ###
 * Fixed: Info List - Resolved warning for undefined array key when selecting image size in the module.

--- a/modules/flip-box/js/frontend.js
+++ b/modules/flip-box/js/frontend.js
@@ -38,7 +38,7 @@ var UABBFlipBox;
         responsive_compatibility        : '',
 
         _init: function() {
-        	var delay = 500,
+        	var delay = 1000, // 1 second delay
         		id = this.id;
 
 			/*if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Yes, with .po and .mo files and GlotPress support.
 
 = 1.5.14 = 
 * Improvement: Revised the README content.
+* Fixed: Flip Box - Box content bounce on page load.
 
 = 1.5.13 = 
 * Fixed: Info List - Resolved warning for undefined array key when selecting image size in the module.


### PR DESCRIPTION
### Description
[BSF-PR-SUMMARY]

Fixed - Flip Box - Box content bounce on page load in UABB Lite

### Screenshots
Before issue - https://bsf.d.pr/v/clBxGN
After Fix - https://bsf.d.pr/v/N66yQ4

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
1. Drag and Drop the Flip Box on Page editor
2. You will notice it bounce to drop 
3. On UI, it will bounce and appear
4. Expected output should be, it should just appear on load.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
