### PR TITLE
EPS-1064: Sanitise code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Yes, with .po and .mo files and GlotPress support.
 
 ## Changelog ##
 
+### 1.6.0.1 ###
+* Improvement: Enhanced the codebase to strengthen security measures.
+
 ### 1.6.0 ###
 * New: UABB Lite now includes translations for Dutch, French, Spanish, and German enhancing multilingual accessibility.
 * New: Added NPS Survey to gather your valuable feedback for UABB Lite!

--- a/admin/bsf-analytics/class-bsf-analytics.php
+++ b/admin/bsf-analytics/class-bsf-analytics.php
@@ -530,7 +530,7 @@ if ( ! class_exists( 'BSF_Analytics' ) ) {
 			}
 
 			// If action coming from general settings page.
-			if ( isset( $_POST['option_page'] ) && 'general' === $_POST['option_page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			if ( isset( $_POST['option_page'] ) && 'general' === $_POST['option_page'] ) {
 
 				if ( get_site_option( 'bsf_analytics_optin' ) ) {
 					update_site_option( 'bsf_analytics_optin', $value );

--- a/admin/bsf-analytics/class-bsf-analytics.php
+++ b/admin/bsf-analytics/class-bsf-analytics.php
@@ -524,13 +524,8 @@ if ( ! class_exists( 'BSF_Analytics' ) ) {
 		 */
 		public function add_option_to_network( $value ) {
 
-			// Verify the nonce to ensure the request is secure.
-			if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( sanitize_text_field( $_POST['_wpnonce'] ) ), 'general-options' ) ) {
-				return; // Stop execution if nonce is invalid.
-			}
-
 			// If action coming from general settings page.
-			if ( isset( $_POST['option_page'] ) && 'general' === $_POST['option_page'] ) {
+			if ( isset( $_POST['option_page'] ) && 'general' === $_POST['option_page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 				if ( get_site_option( 'bsf_analytics_optin' ) ) {
 					update_site_option( 'bsf_analytics_optin', $value );

--- a/admin/bsf-analytics/class-bsf-analytics.php
+++ b/admin/bsf-analytics/class-bsf-analytics.php
@@ -524,6 +524,11 @@ if ( ! class_exists( 'BSF_Analytics' ) ) {
 		 */
 		public function add_option_to_network( $value ) {
 
+			// Verify the nonce to ensure the request is secure.
+			if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( sanitize_text_field( $_POST['_wpnonce'] ) ), 'general-options' ) ) {
+				return; // Stop execution if nonce is invalid.
+			}
+
 			// If action coming from general settings page.
 			if ( isset( $_POST['option_page'] ) && 'general' === $_POST['option_page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 

--- a/modules/advanced-icon/includes/frontend.php
+++ b/modules/advanced-icon/includes/frontend.php
@@ -24,7 +24,7 @@ foreach ( $settings->icons as $icon ) {
 	if ( ! empty( $icon->connections->link ) && empty( $icon->link ) && ! FLBuilderModel::is_builder_active() ) {
 		echo '';
 	} else {
-		echo '<a class="adv-icon-link adv-icon-' . esc_attr( $icon_count ) . '" href="' . esc_url( $icon->link ) . '" target="' . esc_attr( $icon->link_target ) . '" ' . sanitize_text_field( BB_Ultimate_Addon_Helper::get_link_rel( $icon->link_target, $icon->link_nofollow, 0 ) ) . '>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<a class="adv-icon-link adv-icon-' . esc_attr( $icon_count ) . '" href="' . esc_url( $icon->link ) . '" target="' . esc_attr( $icon->link_target ) . '" ' . esc_attr( BB_Ultimate_Addon_Helper::get_link_rel( $icon->link_target, $icon->link_nofollow, 0 ) ) . '>';
 		$imageicon_array = array(
 
 			/* General Section */

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,9 @@ Yes, with .po and .mo files and GlotPress support.
 
 == Changelog ==
 
+= 1.6.0.1 = 
+* Improvement: Enhanced the codebase to strengthen security measures.
+
 = 1.6.0 = 
 * New: UABB Lite now includes translations for Dutch, French, Spanish, and German enhancing multilingual accessibility.
 * New: Added NPS Survey to gather your valuable feedback for UABB Lite!


### PR DESCRIPTION
### Description
[BSF-PR-SUMMARY]

UABB Lite remove the instace of //phpcs:ignore WordPress.Security in the repo.
sanitize_text_field() → Because it’s for sanitizing user input, not escaping output.
esc_attr() → Because it properly escapes attribute values for safe HTML output.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
