### PR TITLE
EPS-1242: load_textdomain notice with WP 6.8 in UABB Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Yes, with .po and .mo files and GlotPress support.
 
 ## Changelog ##
 
+### 1.6.2.1 ###
+* Fixed: Resolved the issue for function _load_textdomain_just_in_time was called incorrectly in WP 6.8.
+
 ### 1.6.2 ###
 * Improved adherence to accessibility standards throughout the plugin.
 

--- a/classes/class-uabb-init.php
+++ b/classes/class-uabb-init.php
@@ -80,8 +80,6 @@ class UABB_Init {
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-compatibility.php';
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-backward.php';
 
-		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-helper.php';
-
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-cloud-templates.php';
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-admin-settings.php';
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-admin-settings-multisite.php';
@@ -96,9 +94,7 @@ class UABB_Init {
 		// fields.
 		require_once BB_ULTIMATE_ADDON_DIR . 'fields/_config.php';
 
-		require_once BB_ULTIMATE_ADDON_DIR . 'classes/uabb-global-settings-form.php';
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/helper.php';
-		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-ui-panel.php';
 
 		// Load the NPS Survey library.
 		if ( ! class_exists( 'Uabb_Lite_Nps_Survey' ) ) {
@@ -126,9 +122,9 @@ class UABB_Init {
 								'popup_logo'        => BB_ULTIMATE_ADDON_URL . 'assets/images/uabb_notice.svg',
 								'plugin_slug'       => 'ultimate-addons-for-beaver-builder-lite', // <your-plugin-slug>
 								'plugin_version'    => BB_ULTIMATE_ADDON_LITE_VERSION,
-								'popup_title'       => __( 'Quick Feedback', 'uabb' ),
+								'popup_title'       => __( 'Quick Feedback' ),
 								'support_url'       => 'https://www.ultimatebeaver.com/contact/',
-								'popup_description' => __( 'If you have a moment, please share why you are deactivating Ultimate Addons for Beaver Builder Lite :', 'uabb' ),
+								'popup_description' => __( 'If you have a moment, please share why you are deactivating Ultimate Addons for Beaver Builder Lite :' ),
 								'show_on_screens'   => array( 'plugins' ),
 							),
 						),
@@ -208,6 +204,11 @@ class UABB_Init {
 		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-iconfonts.php';
 		// require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-model-helper.php';.
 		// Ultimate Modules.
+		// Load the appropriate text-domain notice.
+		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-uabb-helper.php';
+		require_once BB_ULTIMATE_ADDON_DIR . 'classes/uabb-global-settings-form.php';
+		require_once BB_ULTIMATE_ADDON_DIR . 'classes/class-ui-panel.php';
+
 		$this->load_modules();
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,9 @@ Yes, with .po and .mo files and GlotPress support.
 
 == Changelog ==
 
+= 1.6.2.1 = 
+* Fixed: Resolved the issue for function _load_textdomain_just_in_time was called incorrectly in WP 6.8.
+
 = 1.6.2 = 
 * Improved adherence to accessibility standards throughout the plugin.
 


### PR DESCRIPTION
### Description
[BSF-PR-SUMMARY]

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
