### PR TITLE
fix: address medium severity security vulnerabilities

### DIFF
--- a/bb-ultimate-addon.php
+++ b/bb-ultimate-addon.php
@@ -60,7 +60,19 @@ if ( ! class_exists( 'BB_Ultimate_Addon' ) ) {
 				$msg = sprintf( __( 'Unfortunately, plugin could not be activated as the memory allocated by your host has almost exhausted. Plugin recommends that your site should have 15M PHP memory remaining. <br/><br/>Please check <a target="_blank" href="https://www.ultimatebeaver.com/docs/increase-memory-limit-site/">this</a> article for solution or contact <a target="_blank" href="http://store.brainstormforce.com/support">support</a>.<br/><br/><a class="button button-primary" href="%s">Return to Plugins Page</a>', 'uabb' ), network_admin_url( 'plugins.php' ) ); // @codingStandardsIgnoreLine.
 
 				deactivate_plugins( plugin_basename( __FILE__ ) );
-				wp_die( esc_html( $msg ) );
+				wp_die(
+					wp_kses(
+						$msg,
+						array(
+							'a'  => array(
+								'href'   => array(),
+								'target' => array(),
+								'class'  => array(),
+							),
+							'br' => array(),
+						)
+					)
+				);
 			}
 
 			delete_option( 'uabb_hide_branding' );

--- a/classes/class-uabb-cloud-templates.php
+++ b/classes/class-uabb-cloud-templates.php
@@ -446,18 +446,6 @@ if ( ! class_exists( 'UABB_Cloud_Templates' ) ) {
 				</div><!-- #uabb-templates -->
 
 				<?php
-
-				/**
-				 * Debugging
-				 */
-				if ( isset( $_GET['debug'] ) ) {
-					if ( count( $templates ) < 1 ) {
-						?>
-						<h2> <?php esc_html_e( 'Templates are disabled from RestAPI.', 'uabb' ); ?> </h2>
-						<?php
-						print_r( $templates );
-					}
-				}
 			} else {
 
 				// Message for no templates found.

--- a/includes/admin-settings-icons.php
+++ b/includes/admin-settings-icons.php
@@ -20,7 +20,8 @@ if ( ! defined( 'UABB_PREFIX' ) ) {
 
 			<p>
 			<?php
-			echo sprintf( __( 'Clicking the button below will reinstall %1$s icons on your website. If you are facing issues to load %2$s icons then you are at right place to troubleshoot it.', 'uabb' ),UABB_PREFIX, UABB_PREFIX ); // @codingStandardsIgnoreLine.
+			// translators: %1$s and %2$s are the plugin name/prefix.
+			echo esc_html( sprintf( __( 'Clicking the button below will reinstall %1$s icons on your website. If you are facing issues to load %2$s icons then you are at right place to troubleshoot it.', 'uabb' ), UABB_PREFIX, UABB_PREFIX ) );
 			?>
 			</p>
 			<span class="button uabb-reload-icons">

--- a/includes/admin-settings-modules.php
+++ b/includes/admin-settings-modules.php
@@ -13,7 +13,12 @@ if ( ! defined( 'UABB_PREFIX' ) ) {
 ?>
 <div id="fl-uabb-modules-form" class="fl-settings-form uabb-modules-fl-settings-form">
 
-	<h3 class="fl-settings-form-header"><?php echo sprintf( __( '%s Modules', 'uabb' ), UABB_PREFIX ); // @codingStandardsIgnoreLine. ?></h3>
+	<h3 class="fl-settings-form-header">
+		<?php
+		// translators: %s is the plugin name/prefix.
+		echo esc_html( sprintf( __( '%s Modules', 'uabb' ), UABB_PREFIX ) );
+		?>
+	</h3>
 
 	<div id="uabb-modules-form" class="uabb-lite-modules" action="<?php UABBBuilderAdminSettings::render_form_action( 'uabb-modules' ); ?>" method="post">
 		<div class="fl-settings-form-content">

--- a/includes/admin-settings-template-cloud.php
+++ b/includes/admin-settings-template-cloud.php
@@ -10,7 +10,12 @@
 
 	<h3 class="fl-settings-form-header"><?php esc_html_e( 'Template Cloud', 'uabb' ); ?></h3>
 
-	<div class="uabb-go-premium"><?php _e( '<a href="' . BB_ULTIMATE_ADDON_UPGRADE_URL . '" target="_blank">Go Premium</a> and get access to all Page Templates and Sections.', 'uabb' ); // @codingStandardsIgnoreLine. ?></div>
+	<div class="uabb-go-premium">
+		<?php
+		// translators: %s is the upgrade URL.
+		echo wp_kses_post( sprintf( __( '<a href="%s" target="_blank">Go Premium</a> and get access to all Page Templates and Sections.', 'uabb' ), esc_url( BB_ULTIMATE_ADDON_UPGRADE_URL ) ) );
+		?>
+	</div>
 
 	<form id="uabb-cloud-templates-form" action="<?php UABBBuilderAdminSettings::render_form_action( 'uabb-cloud-templates' ); ?>" method="post">
 

--- a/includes/admin-settings-welcome.php
+++ b/includes/admin-settings-welcome.php
@@ -19,8 +19,11 @@
 
 			<div class="fl-welcome-col">
 
-				<p><?php printf( __( 'For more time-saving features and access to our expert support team, <a href="%s" target="_blank">upgrade now!</a> With regular updates, helpful tutorials, we promise to make website building an ultimate journey for you!', 'uabb' ), BB_ULTIMATE_ADDON_UPGRADE_URL ); // @codingStandardsIgnoreLine. ?>
-
+				<p>
+					<?php
+					// translators: %s is the upgrade URL.
+					echo wp_kses_post( sprintf( __( 'For more time-saving features and access to our expert support team, <a href="%s" target="_blank">upgrade now!</a> With regular updates, helpful tutorials, we promise to make website building an ultimate journey for you!', 'uabb' ), esc_url( BB_ULTIMATE_ADDON_UPGRADE_URL ) ) );
+					?>
 				</p>
 
 
@@ -28,7 +31,12 @@
 
 				</p>
 
-				<p><?php printf( __( 'With <a href="%1$s" target="_blank">regular updates</a>, <a href="%2$s" target="_blank">helpful tutorials</a>, we promise to make website building an ultimate journey for you!', 'uabb' ), 'https://www.ultimatebeaver.com/blog/?utm_source=uabb-dashboard&amp;utm_campaign=Lite&amp;utm_medium=welcome-page', 'https://www.ultimatebeaver.com/docs/?utm_source=uabb-dashboard&amp;utm_campaign=Lite&amp;utm_medium=welcome-page' ); // @codingStandardsIgnoreLine. ?></p>
+				<p>
+					<?php
+					// translators: %1$s is the blog URL, %2$s is the docs URL.
+					echo wp_kses_post( sprintf( __( 'With <a href="%1$s" target="_blank">regular updates</a>, <a href="%2$s" target="_blank">helpful tutorials</a>, we promise to make website building an ultimate journey for you!', 'uabb' ), esc_url( 'https://www.ultimatebeaver.com/blog/?utm_source=uabb-dashboard&utm_campaign=Lite&utm_medium=welcome-page' ), esc_url( 'https://www.ultimatebeaver.com/docs/?utm_source=uabb-dashboard&utm_campaign=Lite&utm_medium=welcome-page' ) ) );
+					?>
+				</p>
 
 			</div>
 
@@ -38,7 +46,12 @@
 		</div>
 
 		<h4><?php esc_html_e( 'Join our Community!', 'uabb' ); ?></h4>
-		<p><?php printf( __( 'Want to connect with us to know more? Or have some suggestions we can take forward? <a href="%s" target="_blank">Join our Facebook community</a>, where a number of professional and newbie Beavers share their views and suggestions for the Ultimate Addons.', 'uabb' ), BB_ULTIMATE_ADDON_FB_URL );  // @codingStandardsIgnoreLine. ?></p>
+		<p>
+			<?php
+			// translators: %s is the Facebook community URL.
+			echo wp_kses_post( sprintf( __( 'Want to connect with us to know more? Or have some suggestions we can take forward? <a href="%s" target="_blank">Join our Facebook community</a>, where a number of professional and newbie Beavers share their views and suggestions for the Ultimate Addons.', 'uabb' ), esc_url( BB_ULTIMATE_ADDON_FB_URL ) ) );
+			?>
+		</p>
 
 	</div>
 </div>

--- a/includes/ui-panel-sections.php
+++ b/includes/ui-panel-sections.php
@@ -56,7 +56,7 @@ if ( ! defined( 'UABB_PREFIX' ) ) {
 								?>
 								<div class="fl-builder-blocks-section">
 									<span class="fl-builder-blocks-section-title">
-										<?php echo __( $cat['name'], 'uabb' ); // @codingStandardsIgnoreLine.?>
+										<?php echo esc_html( __( $cat['name'], 'uabb' ) ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText ?>
 										<i class="fa fa-chevron-down"></i>
 									</span>
 									<div class="fl-builder-blocks-section-content fl-builder-row-templates">
@@ -91,7 +91,7 @@ if ( ! defined( 'UABB_PREFIX' ) ) {
 
 				<?php if ( BB_Ultimate_Addon_Helper::get_builder_uabb_branding( 'uabb-enable-template-cloud' ) ) { ?>
 				<div class="fl-builder-modules-cta">
-					<a href="#" onclick="window.open('<?php echo admin_url(); ?>options-general.php?page=uabb-builder-settings#uabb-cloud-templates');" target="_blank"><i class="fa fa-external-link-square"></i> <?php echo sprintf( __( 'Note - You can enable, disable and manage %s sections here.', 'uabb' ), UABB_PREFIX ); // @codingStandardsIgnoreLine. ?></a>
+					<a href="#" onclick="window.open('<?php echo esc_url( admin_url( 'options-general.php?page=uabb-builder-settings#uabb-cloud-templates' ) ); ?>');" target="_blank"><i class="fa fa-external-link-square"></i> <?php echo esc_html( sprintf( __( 'Note - You can enable, disable and manage %s sections here.', 'uabb' ), UABB_PREFIX ) ); // phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment ?></a>
 				</div>
 				<?php } ?>
 				<div class="fl-builder-modules-cta">


### PR DESCRIPTION
Closes #208

## Summary
- **M1** — `wp_die()` now uses `wp_kses()` with an explicit allowlist (`<a>`, `<br>`) so the activation error message renders correctly instead of escaped HTML
- **M2** — Removed `?debug` GET parameter block that exposed internal template data via `print_r()` without additional auth checks
- **M3** — `UABB_PREFIX` output wrapped in `esc_html(sprintf())` in icons and modules settings pages; `admin_url()` properly escaped in `ui-panel-sections.php`
- **M4** — `_e()` with raw HTML replaced by `echo wp_kses_post(sprintf(..., esc_url()))` in template cloud settings
- **M5** — Category name in `ui-panel-sections.php` wrapped in `esc_html()` while preserving `__()` translation
- **M6** — All three `printf()` calls in welcome page replaced with `echo wp_kses_post(sprintf(..., esc_url()))` for proper URL escaping

## Files changed
- `bb-ultimate-addon.php`
- `classes/class-uabb-cloud-templates.php`
- `includes/admin-settings-icons.php`
- `includes/admin-settings-modules.php`
- `includes/admin-settings-template-cloud.php`
- `includes/admin-settings-welcome.php`
- `includes/ui-panel-sections.php`

## Test plan
- [ ] Activate plugin on a low-memory site — error page should render with working links (not escaped HTML)
- [ ] Confirm `?debug` query param on cloud templates page no longer dumps template data
- [ ] Verify settings pages (Icons, Modules, Template Cloud, Welcome) render correctly with no visible escaped HTML
- [ ] Confirm `composer run lint` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)