### PR TITLE
fix: escape all output to prevent XSS vulnerabilities (closes #215)

### DIFF
--- a/fields/uabb-gradient/uabb-gradient.php
+++ b/fields/uabb-gradient/uabb-gradient.php
@@ -77,49 +77,49 @@ if ( ! class_exists( 'UABB_Gradient' ) ) {
 			);
 
 			$colorpick_class = 'bb-colorpick';
-			$html            = '<div class="uabb-gradient-wrapper ' . $colorpick_class . '">';
+			$html            = '<div class="uabb-gradient-wrapper ' . esc_attr( $colorpick_class ) . '">';
 
 			/* Color One */
 			$color_one_class = ( empty( $value['color_one'] ) ) ? ' fl-color-picker-empty' : '';
-			$html           .= '<div class="uabb-gradient-item bb-color uabb-gradient-color-one fl-field" data-type="color" data-preview=\'' . $preview . '\'>';
+			$html           .= '<div class="uabb-gradient-item bb-color uabb-gradient-color-one fl-field" data-type="color" data-preview=\'' . esc_attr( $preview ) . '\'>';
 			$html           .= '<label for="uabb-gradient-color-one" class="uabb-gradient-label">Color 1</label>';
 			$html           .= '<div class="fl-color-picker">';
-			$html           .= '<div class="fl-color-picker-color' . $color_one_class . '"></div>';
+			$html           .= '<div class="fl-color-picker-color' . esc_attr( $color_one_class ) . '"></div>';
 			$html           .= '<div class="fl-color-picker-clear"><div class="fl-color-picker-icon-remove"></div></div>';
-			$html           .= '<input name="' . $name . '[][color_one]' . '" type="hidden" value="' . $value['color_one'] . '" class="fl-color-picker-value" />';
+			$html           .= '<input name="' . esc_attr( $name ) . '[][color_one]" type="hidden" value="' . esc_attr( $value['color_one'] ) . '" class="fl-color-picker-value" />';
 			$html           .= '</div>';
 			$html           .= '</div>';
 
 			/* Color Two */
 			$color_two_class = ( empty( $value['color_two'] ) ) ? ' fl-color-picker-empty' : '';
-			$html           .= '<div class="uabb-gradient-item bb-color uabb-gradient-color-two fl-field" data-type="color" data-preview=\'' . $preview . '\'>';
+			$html           .= '<div class="uabb-gradient-item bb-color uabb-gradient-color-two fl-field" data-type="color" data-preview=\'' . esc_attr( $preview ) . '\'>';
 			$html           .= '<label for="uabb-gradient-color-two" class="uabb-gradient-label">Color 2</label>';
 			$html           .= '<div class="fl-color-picker">';
-			$html           .= '<div class="fl-color-picker-color' . $color_two_class . '"></div>';
+			$html           .= '<div class="fl-color-picker-color' . esc_attr( $color_two_class ) . '"></div>';
 			$html           .= '<div class="fl-color-picker-clear"><div class="fl-color-picker-icon-remove"></div></div>';
-			$html           .= '<input name="' . $name . '[][color_two]' . '" type="hidden" value="' . $value['color_two'] . '" class="fl-color-picker-value" />';
+			$html           .= '<input name="' . esc_attr( $name ) . '[][color_two]" type="hidden" value="' . esc_attr( $value['color_two'] ) . '" class="fl-color-picker-value" />';
 			$html           .= '</div>';
 			$html           .= '</div>';
 
 			/* Direction */
-			$html .= '<div class="uabb-gradient-item uabb-gradient-direction fl-field" data-type="select" data-preview=\'' . $preview . '\'>';
+			$html .= '<div class="uabb-gradient-item uabb-gradient-direction fl-field" data-type="select" data-preview=\'' . esc_attr( $preview ) . '\'>';
 			$html .= '<label for="uabb-gradient-direction" class="uabb-gradient-label">Direction</label>';
-			$html .= '<select name="' . $name . '[][direction]' . '" class="uabb-gradient-direction-select">';
+			$html .= '<select name="' . esc_attr( $name ) . '[][direction]" class="uabb-gradient-direction-select">';
 			foreach ( $direction as $direction_key => $direction_value ) {
 				$selected = '';
 				if ( $direction_key === $value['direction'] ) {
 					$selected = 'selected="selected"';
 				}
-				$html .= '<option value="' . $direction_key . '" ' . $selected . '>' . $direction_value . '</option>';
+				$html .= '<option value="' . esc_attr( $direction_key ) . '" ' . $selected . '>' . esc_html( $direction_value ) . '</option>';
 			}
 			$html .= '</select>';
 			$html .= '</div>';
 
 			/* Angle */
 			$angle = ( isset( $value['angle'] ) ) ? $value['angle'] : '';
-			$html .= '<div class="uabb-gradient-item uabb-gradient-angle fl-field" data-type="text" data-preview=\'' . $preview . '\' >';
+			$html .= '<div class="uabb-gradient-item uabb-gradient-angle fl-field" data-type="text" data-preview=\'' . esc_attr( $preview ) . '\' >';
 			$html .= '<label for="uabb-gradient-angle" class="uabb-gradient-label">Angle</label>';
-			$html .= '<input type="text" class="uabb-gradient-angle-input" name="' . $name . '[][angle]' . '" maxlength="3" size="6" value="' . $angle . '" />';
+			$html .= '<input type="text" class="uabb-gradient-angle-input" name="' . esc_attr( $name ) . '[][angle]" maxlength="3" size="6" value="' . esc_attr( $angle ) . '" />';
 			$html .= '<span class="fl-field-description">deg</span>';
 			$html .= '</div>';
 			$html .= '</div>';

--- a/includes/ui-panel-presets.php
+++ b/includes/ui-panel-presets.php
@@ -54,7 +54,7 @@ if ( ! defined( 'UABB_PREFIX' ) ) {
 								?>
 								<div class="fl-builder-blocks-section">
 									<span class="fl-builder-blocks-section-title">
-										<?php echo __( $cat['name'], 'uabb' ); // @codingStandardsIgnoreLine.?>
+										<?php echo esc_html( $cat['name'] ); ?>
 										<i class="fa fa-chevron-down"></i>
 									</span>
 									<div class="fl-builder-blocks-section-content fl-builder-module-templates">
@@ -88,7 +88,7 @@ if ( ! defined( 'UABB_PREFIX' ) ) {
 				<?php do_action( 'uabb_fl_builder_ui_panel_after_presets' ); ?>
 
 				<div class="fl-builder-modules-cta">
-					<a href="#" onclick="window.open('<?php echo admin_url(); ?>options-general.php?page=fl-builder-settings#uabb-template-manager');" target="_blank"><i class="fa fa-external-link-square"></i> <?php echo sprintf( __( 'Note - You can enable, disable and manage %s presets here.', 'uabb' ), UABB_PREFIX ); // @codingStandardsIgnoreLine. ?></a>
+					<a href="#" onclick="window.open('<?php echo esc_url( admin_url( 'options-general.php?page=fl-builder-settings#uabb-template-manager' ) ); ?>');" target="_blank"><i class="fa fa-external-link-square"></i> <?php echo esc_html( sprintf( /* translators: %s: UABB prefix branding */ __( 'Note - You can enable, disable and manage %s presets here.', 'uabb' ), UABB_PREFIX ) ); ?></a>
 				</div>
 				<div class="fl-builder-modules-cta">
 					<a href="#" target="_self"><?php echo esc_html__( 'Note - Images used in the templates are hotlinked from our server and are subject to copyright. It is strongly recommended that you replace them with your own.', 'uabb' ); ?></a>

--- a/modules/image-icon/image-icon.php
+++ b/modules/image-icon/image-icon.php
@@ -271,13 +271,13 @@ class ImageIconModule extends FLBuilderModule {
 		$photo = $this->get_data();
 
 		if ( ! empty( $photo->alt ) ) {
-			return htmlspecialchars( $photo->alt, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->alt );
 		} elseif ( ! empty( $photo->description ) ) {
-			return htmlspecialchars( $photo->description, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->description );
 		} elseif ( ! empty( $photo->caption ) ) {
-			return htmlspecialchars( $photo->caption, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->caption );
 		} elseif ( ! empty( $photo->title ) ) {
-			return htmlspecialchars( $photo->title, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->title );
 		}
 
 		return null;

--- a/modules/image-separator/image-separator.php
+++ b/modules/image-separator/image-separator.php
@@ -258,13 +258,13 @@ class UABBImageSeparatorModule extends FLBuilderModule {
 		$photo = $this->get_data();
 
 		if ( ! empty( $photo->alt ) ) {
-			return htmlspecialchars( $photo->alt, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->alt );
 		} elseif ( ! empty( $photo->description ) ) {
-			return htmlspecialchars( $photo->description, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->description );
 		} elseif ( ! empty( $photo->caption ) ) {
-			return htmlspecialchars( $photo->caption, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->caption );
 		} elseif ( ! empty( $photo->title ) ) {
-			return htmlspecialchars( $photo->title, ENT_QUOTES, 'UTF-8' );  // Added 'UTF-8' encoding.
+			return esc_attr( $photo->title );
 		}
 		return null;
 	}

--- a/modules/info-list/includes/frontend.css.php
+++ b/modules/info-list/includes/frontend.css.php
@@ -389,7 +389,10 @@ foreach ( $settings->add_list_item as $item ) {
 			$img_size[0] = ( isset( FLBuilderPhoto::get_attachment_data( $item->photo )->width ) ) ? FLBuilderPhoto::get_attachment_data( $item->photo )->width : '';
 			$img_size[1] = ( isset( FLBuilderPhoto::get_attachment_data( $item->photo )->height ) ) ? FLBuilderPhoto::get_attachment_data( $item->photo )->height : '';
 			elseif ( '' !== trim( $item->photo_url ) ) :
-				$img_size = getimagesize( $item->photo_url );
+				$photo_url = esc_url_raw( $item->photo_url );
+				if ( wp_http_validate_url( $photo_url ) ) {
+					$img_size = @getimagesize( $photo_url ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				}
 			endif;
 
 			if ( isset( $img_size[0] ) && isset( $img_size[1] ) && ( 0 !== intval( $img_size[0] ) ) && ( 0 !== intval( $img_size[1] ) ) ) :

--- a/modules/info-table/includes/frontend.php
+++ b/modules/info-table/includes/frontend.php
@@ -84,7 +84,7 @@ if ( isset( $settings->it_link_nofollow ) ) {
 		</div>
 		<?php if ( 'cta' === $settings->it_link_type && 'design02' !== $settings->box_design ) { ?>
 		<div class="info-table-button">
-			<a href="<?php echo esc_url( $settings->it_link ); ?>" target="<?php echo esc_attr( $settings->it_link_target ); ?>"><?php echo esc_html( $settings->button_text ); ?></a>
+			<a href="<?php echo esc_url( $settings->it_link ); ?>" target="<?php echo esc_attr( $settings->it_link_target ); ?>" <?php UABB_Helper::get_link_rel( esc_attr( $settings->it_link_target ), $link_nofollow, 1 ); ?>><?php echo esc_html( $settings->button_text ); ?></a>
 		</div>
 		<?php } ?>
 	</div>

--- a/modules/uabb-heading/includes/frontend.php
+++ b/modules/uabb-heading/includes/frontend.php
@@ -30,26 +30,27 @@ if ( ! isset( $module ) ) {
 						<?php $module->render_image(); ?>
 						<?php
 						if ( 'line_text' === $settings->separator_style ) {
-							echo '<' . esc_attr( $settings->separator_text_tag_selection ) . ' class="uabb-divider-text">' . esc_attr( $settings->text_inline ) . '</' . esc_attr( $settings->separator_text_tag_selection ) . '>';
+							echo '<' . esc_html( $separator_tag ) . ' class="uabb-divider-text">' . esc_html( $settings->text_inline ) . '</' . esc_html( $separator_tag ) . '>';
 						}
 						?>
-					</div>			 		    
+					</div>
 					<div class="uabb-separator-line uabb-side-right">
 						<span></span>
-					</div> 
+					</div>
 				</div>
 			<?php } ?>
 			<?php if ( 'line' === $settings->separator_style ) { ?>
 				<div class="uabb-separator"></div>
 			<?php } ?>
-		</div> 
+		</div>
 	<?php } ?>
 	<?php
 	// Define a whitelist of allowed tags.
-		$allowed_tags = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' );
-		$heading_tag  = in_array( $settings->tag, $allowed_tags, true ) ? $settings->tag : 'h3';
+		$allowed_tags     = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'p', 'span' );
+		$heading_tag      = in_array( $settings->tag, $allowed_tags, true ) ? $settings->tag : 'h3';
+		$separator_tag    = isset( $settings->separator_text_tag_selection ) && in_array( $settings->separator_text_tag_selection, $allowed_tags, true ) ? $settings->separator_text_tag_selection : 'h3';
 	?>
-	<<?php echo esc_attr( $heading_tag ); ?> class="uabb-heading">
+	<<?php echo esc_html( $heading_tag ); ?> class="uabb-heading">
 		<?php if ( ! empty( $settings->link ) ) : ?>
 			<a href="<?php echo esc_url( $settings->link ); ?>" title="<?php echo esc_attr( $settings->heading ); ?>" target="<?php echo esc_attr( $settings->link_target ); ?>" <?php BB_Ultimate_Addon_Helper::get_link_rel( esc_attr( $settings->link_target ), $settings->link_nofollow, 1 ); ?> aria-label="<?php echo esc_attr__( 'Go to ', 'uabb' ) . esc_url( $settings->link ); ?>">
 			<?php endif; ?>
@@ -57,7 +58,7 @@ if ( ! isset( $module ) ) {
 			<?php if ( ! empty( $settings->link ) ) : ?>
 			</a>
 		<?php endif; ?>
-	</<?php echo esc_attr( $heading_tag ); ?>>
+	</<?php echo esc_html( $heading_tag ); ?>>
 
 	<?php if ( 'center' === $settings->separator_position ) { ?>
 		<div class="uabb-module-content uabb-separator-parent">			
@@ -70,13 +71,13 @@ if ( ! isset( $module ) ) {
 						<?php $module->render_image(); ?>
 						<?php
 						if ( 'line_text' === $settings->separator_style ) {
-							echo '<' . esc_attr( $settings->separator_text_tag_selection ) . ' class="uabb-divider-text">' . esc_html( $settings->text_inline ) . '</' . esc_attr( $settings->separator_text_tag_selection ) . '>';
+							echo '<' . esc_html( $separator_tag ) . ' class="uabb-divider-text">' . esc_html( $settings->text_inline ) . '</' . esc_html( $separator_tag ) . '>';
 						}
 						?>
-					</div>					    
+					</div>
 					<div class="uabb-separator-line uabb-side-right">
 						<span></span>
-					</div> 
+					</div>
 				</div>
 			<?php } ?>
 			<?php if ( 'line' === $settings->separator_style ) { ?>
@@ -102,7 +103,7 @@ if ( ! isset( $module ) ) {
 						<?php $module->render_image(); ?>
 						<?php
 						if ( 'line_text' === $settings->separator_style ) {
-								echo '<' . esc_attr( $settings->separator_text_tag_selection ) . ' class="uabb-divider-text">' . esc_html( $settings->text_inline ) . '</' . esc_attr( $settings->separator_text_tag_selection ) . '>';
+								echo '<' . esc_html( $separator_tag ) . ' class="uabb-divider-text">' . esc_html( $settings->text_inline ) . '</' . esc_html( $separator_tag ) . '>';
 						}
 						?>
 					</div>


### PR DESCRIPTION
## Summary
- Add `esc_attr()` to all HTML attribute values in gradient field builder (`fields/uabb-gradient/uabb-gradient.php`)
- Escape `admin_url()` and `sprintf()` output in `includes/ui-panel-presets.php`
- Replace `htmlspecialchars()` with `esc_attr()` in image-icon and image-separator `get_alt()` methods
- Fix `esc_attr()` to `esc_html()` for HTML tag content in uabb-heading module
- Add tag allowlist validation for `separator_text_tag_selection`
- Validate URL with `wp_http_validate_url()` before `getimagesize()` to prevent SSRF in info-list
- Add `rel` attribute via `get_link_rel()` on info-table CTA links with `target="_blank"`

## Files Changed
- `fields/uabb-gradient/uabb-gradient.php`
- `includes/ui-panel-presets.php`
- `modules/image-icon/image-icon.php`
- `modules/image-separator/image-separator.php`
- `modules/info-list/includes/frontend.css.php`
- `modules/info-table/includes/frontend.php`
- `modules/uabb-heading/includes/frontend.php`

## Test plan
- [ ] Verify gradient field renders correctly in Beaver Builder editor
- [ ] Verify UI panel presets load and display properly
- [ ] Verify image-icon and image-separator modules display alt text correctly
- [ ] Verify heading module renders separator text with all tag options (h1-h6, div, p, span)
- [ ] Verify info-list module with external photo URLs still calculates image dimensions
- [ ] Verify info-table CTA button links work correctly with target="_blank"

🤖 Generated with [Claude Code](https://claude.com/claude-code)