### PR TITLE
fix: replace file_get_contents and direct filesystem ops with WP_Filesystem (closes #216)

### DIFF
--- a/classes/class-uabb-iconfonts.php
+++ b/classes/class-uabb-iconfonts.php
@@ -96,24 +96,27 @@ class UABB_IconFonts {
 	 * @param array $dst an object to get destination of the file.
 	 */
 	public function recurse_copy( $src, $dst ) {
-		$dir = opendir( $src );
-
-		// Create directory if not exist.
-		if ( ! is_dir( $dst ) ) {
-			@mkdir( $dst ); //phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		global $wp_filesystem;
+		if ( empty( $wp_filesystem ) ) {
+			require_once ABSPATH . '/wp-admin/includes/file.php';
+			WP_Filesystem();
 		}
 
-		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
-		while ( false !== ( $file = readdir( $dir ) ) ) {
-			if ( ( '.' !== $file ) && ( '..' !== $file ) ) {
-				if ( is_dir( $src . '/' . $file ) ) {
+		// Create directory if not exist.
+		if ( ! $wp_filesystem->is_dir( $dst ) ) {
+			$wp_filesystem->mkdir( $dst );
+		}
+
+		$dirlist = $wp_filesystem->dirlist( $src );
+		if ( ! empty( $dirlist ) ) {
+			foreach ( $dirlist as $file => $fileinfo ) {
+				if ( 'd' === $fileinfo['type'] ) {
 					$this->recurse_copy( $src . '/' . $file, $dst . '/' . $file );
 				} else {
-					copy( $src . '/' . $file, $dst . '/' . $file );
+					$wp_filesystem->copy( $src . '/' . $file, $dst . '/' . $file, true );
 				}
 			}
 		}
-		closedir( $dir );
 	}
 }
 

--- a/classes/class-ui-panel.php
+++ b/classes/class-ui-panel.php
@@ -172,8 +172,15 @@ class UABB_UI_Panels {
 	 * @return string|false
 	 */
 	public function fl_uabb_render_js( $js, $nodes, $global_settings ) {
-		$temp = file_get_contents( BB_ULTIMATE_ADDON_DIR . 'assets/js/uabb-frontend.js' ) . $js;
-		$js   = $temp;
+		global $wp_filesystem;
+		if ( empty( $wp_filesystem ) ) {
+			require_once ABSPATH . '/wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+		$file_path = BB_ULTIMATE_ADDON_DIR . 'assets/js/uabb-frontend.js';
+		$contents  = $wp_filesystem->get_contents( $file_path );
+		$temp      = ( false !== $contents ? $contents : '' ) . $js;
+		$js        = $temp;
 		return $js;
 	}
 
@@ -187,9 +194,15 @@ class UABB_UI_Panels {
 	 * @return string|false
 	 */
 	public function fl_uabb_render_css( $css, $nodes, $global_settings ) {
-
-		$css .= file_get_contents( BB_ULTIMATE_ADDON_DIR . 'assets/css/uabb-frontend.css' );
-		$css .= include BB_ULTIMATE_ADDON_DIR . 'assets/dynamic-css/uabb-theme-dynamic-css.php';
+		global $wp_filesystem;
+		if ( empty( $wp_filesystem ) ) {
+			require_once ABSPATH . '/wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+		$file_path = BB_ULTIMATE_ADDON_DIR . 'assets/css/uabb-frontend.css';
+		$contents  = $wp_filesystem->get_contents( $file_path );
+		$css      .= ( false !== $contents ? $contents : '' );
+		$css      .= include BB_ULTIMATE_ADDON_DIR . 'assets/dynamic-css/uabb-theme-dynamic-css.php';
 
 		return $css;
 	}

--- a/modules/flip-box/flip-box.php
+++ b/modules/flip-box/flip-box.php
@@ -49,7 +49,12 @@ class FlipBoxModule extends FLBuilderModule {
 		}
 
 		if ( file_exists( $path ) ) {
-			$icon_content = file_get_contents( $path );
+			global $wp_filesystem;
+			if ( empty( $wp_filesystem ) ) {
+				require_once ABSPATH . '/wp-admin/includes/file.php';
+				WP_Filesystem();
+			}
+			$icon_content = $wp_filesystem->get_contents( $path );
 			return false !== $icon_content ? $icon_content : '';
 		}
 

--- a/modules/uabb-star-rating/uabb-star-rating.php
+++ b/modules/uabb-star-rating/uabb-star-rating.php
@@ -54,7 +54,12 @@ class UABBStarRatingModule extends FLBuilderModule {
 		}
 
 		if ( file_exists( $path ) ) {
-			$icon_content = file_get_contents( $path );
+			global $wp_filesystem;
+			if ( empty( $wp_filesystem ) ) {
+				require_once ABSPATH . '/wp-admin/includes/file.php';
+				WP_Filesystem();
+			}
+			$icon_content = $wp_filesystem->get_contents( $path );
 			return false !== $icon_content ? $icon_content : '';
 		}
 


### PR DESCRIPTION
## Summary
- Replace `file_get_contents()` with `$wp_filesystem->get_contents()` in 3 files
- Replace `opendir()`, `@mkdir()`, `copy()`, `readdir()`, `closedir()` with WP_Filesystem API equivalents in `class-uabb-iconfonts.php`
- All filesystem operations now use the WordPress `WP_Filesystem` API as required by wp.org

## Files Changed
- `classes/class-ui-panel.php` — JS/CSS rendering methods
- `classes/class-uabb-iconfonts.php` — `recurse_copy()` method
- `modules/flip-box/flip-box.php` — `get_icon()` method
- `modules/uabb-star-rating/uabb-star-rating.php` — `get_icon()` method

## Test plan
- [ ] Verify Beaver Builder editor loads JS/CSS correctly (ui-panel renders)
- [ ] Verify icon fonts copy correctly on plugin activation
- [ ] Verify flip-box module SVG icons render correctly
- [ ] Verify star-rating module icons render correctly
- [ ] Test on fresh install to ensure WP_Filesystem initializes properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)