### PR TITLE
fix: correct text domain in translation function calls (closes #217)

### DIFF
--- a/classes/class-uabb-admin-settings.php
+++ b/classes/class-uabb-admin-settings.php
@@ -116,13 +116,13 @@ final class UABBBuilderAdminSettings {
 							</div>
 						</div>',
 					$image_path,
-					__( 'Hello! Thank you for choosing the Ultimate Addon for Beaver Builder to build this website!', 'ultimate-addon-for-beaver-builder', 'uabb' ),
-					__( 'Would you please mind sharing your views and give it a 5 star rating on the WordPress repository?', 'ultimate-addon-for-beaver-builder', 'uabb' ),
+					__( 'Hello! Thank you for choosing the Ultimate Addon for Beaver Builder to build this website!', 'uabb' ),
+					__( 'Would you please mind sharing your views and give it a 5 star rating on the WordPress repository?', 'uabb' ),
 					'https://wordpress.org/support/plugin/ultimate-addons-for-beaver-builder-lite/reviews/?filter=5',
-					__( 'Ok, you deserve it', 'ultimate-addon-for-beaver-builder', 'uabb' ),
+					__( 'Ok, you deserve it', 'uabb' ),
 					MONTH_IN_SECONDS,
-					__( 'Nope, maybe later', 'ultimate-addon-for-beaver-builder', 'uabb' ),
-					__( 'I already did', 'ultimate-addon-for-beaver-builder', 'uabb' )
+					__( 'Nope, maybe later', 'uabb' ),
+					__( 'I already did', 'uabb' )
 				),
 				'repeat-notice-after'        => MONTH_IN_SECONDS,
 				'display-notice-after'       => ( 2 * WEEK_IN_SECONDS ), // Display notice after 2 weeks.


### PR DESCRIPTION
## Summary
- Fix 5 `__()` calls that were passing 3 arguments with wrong text domain `'ultimate-addon-for-beaver-builder'`
- Changed to standard 2-argument format with correct text domain `'uabb'`
- Translations for review notice strings will now load properly

## Files Changed
- `classes/class-uabb-admin-settings.php` — lines 119-125

## Test plan
- [ ] Verify admin review notice displays correctly
- [ ] Verify translations load for the review notice strings
- [ ] Run `wp i18n make-pot` to confirm no text domain warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)