### PR TITLE
reverted tracking setting

### DIFF
--- a/classes/class-uabb-init.php
+++ b/classes/class-uabb-init.php
@@ -128,11 +128,11 @@ class UABB_Init {
 	 * Precedence (most → least specific):
 	 *   1. `uabb_usage_optin` already set ('yes' or 'no')      → preserved as-is.
 	 *   2. Legacy `bsf_usage_optin` set ('yes' or 'no')        → migrated to the new key.
-	 *   3. Genuinely fresh site (neither key set anywhere)     → default to 'yes'.
+	 *   3. Genuinely fresh site (neither key set anywhere)     → left unset.
 	 *
-	 * Backward compatibility: a user who has explicitly opted out — either via the
-	 * current notice or the legacy key — stays opted out. Only sites that have never
-	 * recorded a choice receive the default-on behaviour.
+	 * Fresh sites stay opted out by default — the BSF Analytics library treats
+	 * an absent / false opt-in as "no telemetry" and shows its own opt-in
+	 * notice so the user makes the choice explicitly.
 	 *
 	 * @since x.x.x
 	 * @access public
@@ -156,13 +156,6 @@ class UABB_Init {
 			if ( false !== $time ) {
 				update_option( 'uabb_usage_installed_time', $time );
 			}
-			return;
-		}
-
-		// Fresh site with no recorded choice — default to opted-in.
-		update_option( 'uabb_usage_optin', 'yes' );
-		if ( false === get_option( 'uabb_usage_installed_time', false ) ) {
-			update_option( 'uabb_usage_installed_time', time() );
 		}
 	}
 


### PR DESCRIPTION
### Description
**Main Purpose**: This pull request reverts changes made to the tracking settings in the analytics tracking module to ensure that fresh sites do not default to an opted-in state, thus preserving user choice regarding telemetry.

**Key Changes**:
- Updated the logic in `class-uabb-init.php` to leave the tracking opt-in state unset for fresh sites, instead of defaulting to 'yes.'
- Modified comments to clarify that fresh sites without recorded choices will now remain opted out, allowing the BSF Analytics library to prompt users for explicit consent.

**Additional Notes**: 
- Reviewers should pay particular attention to the implications of this change on user tracking and data analytics. There are no backward compatibility issues since users who have opted out remain opted out, and this change emphasizes user consent. Please verify that the logic properly aligns with expected user experience regarding telemetry.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
