### PR TITLE
fix: send kpi_records in BSF analytics contract shape

### DIFF
--- a/classes/class-uabb-analytics.php
+++ b/classes/class-uabb-analytics.php
@@ -134,8 +134,28 @@ if ( ! class_exists( 'UABB_Analytics' ) ) {
 					'days_since_install'    => self::days_since_install(),
 					'beaver_builder_active' => defined( 'FL_BUILDER_VERSION' ),
 					'is_multisite'          => is_multisite(),
+					'source'                => self::get_install_source( 'ultimate-addons-for-beaver-builder-lite' ),
 				)
 			);
+		}
+
+		/**
+		 * Resolve the install source for the activation event.
+		 *
+		 * Reads the BSF UTM referer table written by other BSF products that installed
+		 * us via TGM/PluginActivator. Returns the referer slug (e.g. `astra`,
+		 * `cartflows`) when present, or `direct` when the user installed us directly.
+		 *
+		 * @since 1.6.9
+		 * @param string $product_slug This product's slug as recorded in `bsf_product_referers`.
+		 * @return string
+		 */
+		private static function get_install_source( $product_slug ) {
+			$referers = get_option( 'bsf_product_referers', array() );
+			if ( ! is_array( $referers ) || empty( $referers[ $product_slug ] ) ) {
+				return 'direct';
+			}
+			return (string) $referers[ $product_slug ];
 		}
 
 		/**
@@ -316,15 +336,15 @@ if ( ! class_exists( 'UABB_Analytics' ) ) {
 		 * Build the KPI payload from the latest snapshot written by the weekly
 		 * module-usage cron.
 		 *
-		 * The cron stores exactly one record — the most recent week's calculation
-		 * — keyed by that cron-tick's date. Analytics reshapes it into the
-		 * `kpi_records` wire format. Empty (fresh install / opted out before first
-		 * cron tick) returns an empty array.
+		 * The writer (`save_kpi_snapshot()`) already persists each day in the BSF
+		 * analytics ingestion contract shape, so the reader returns it verbatim.
+		 * Empty (fresh install / opted out before first cron tick) returns an
+		 * empty array.
 		 *
-		 * Shape: `[ 'Y-m-d' => [ [ 'kpi_name' => ..., 'kpi_value' => (float) ... ] ] ]`.
+		 * Shape: `[ 'Y-m-d' => [ 'numeric_values' => [ kpi_name => kpi_value ] ] ]`.
 		 *
 		 * @since 1.6.8
-		 * @return array<string, array<int, array{kpi_name:string, kpi_value:float}>>
+		 * @return array<string, array{numeric_values: array<string, int|float>}>
 		 */
 		private function get_kpi_tracking_data() {
 			$snapshots = get_option( 'uabb_kpi_daily_snapshots', array() );
@@ -337,18 +357,7 @@ if ( ! class_exists( 'UABB_Analytics' ) ) {
 				if ( ! is_array( $snapshot ) || empty( $snapshot['numeric_values'] ) ) {
 					continue;
 				}
-
-				$day_records = array();
-				foreach ( (array) $snapshot['numeric_values'] as $kpi_name => $kpi_value ) {
-					$day_records[] = array(
-						'kpi_name'  => (string) $kpi_name,
-						'kpi_value' => (float) $kpi_value,
-					);
-				}
-
-				if ( ! empty( $day_records ) ) {
-					$records[ (string) $date ] = $day_records;
-				}
+				$records[ (string) $date ] = $snapshot;
 			}
 
 			return $records;


### PR DESCRIPTION
The reader in get_kpi_tracking_data() was unwrapping each day's snapshot into a list-of-objects, which AnalyticsJob::handleKpiRecords() rejects because it checks for a numeric_values map. As a result no UABB Lite KPI data was reaching the uabb_daily_kpis ClickHouse table.

The writer (save_kpi_snapshot) already persists each day in the ingestion contract shape, so the reader now returns snapshots verbatim.

Also adds the install source attribution to the plugin_activated event so the analytics pipeline can distinguish direct installs from TGM / PluginActivator referer flows (astra, cartflows, etc).

Refs GIT-691.

### Description
**Main Purpose**: This pull request aims to address an issue with the analytics tracking within the Ultimate Addons for Beaver Builder (UABB) plugin by ensuring the Key Performance Indicator (KPI) data is sent in the correct shape as per the BSF analytics contract.

**Key Changes**: 
- The `add_uabb_analytics_data` method in `class-uabb-analytics.php` has been updated to include an additional field `source` in the event detection logic, indicating where the plugin was installed from. This is determined by the new `get_install_source` method, which checks a stored option for referers and defaults to `direct` if none are found.
- The `get_kpi_tracking_data` method has been modified to return the KPI data directly from the daily snapshots without restructuring it into a secondary output format. This significantly simplifies the code and directly adheres to the expected analytics contract shape.

**Additional Notes**: 
- Reviewers should pay close attention to the changes in the `get_kpi_tracking_data` method to ensure the output format aligns with existing analytics infrastructure. 
- There may be an impact on historical data interpretation since the new format is expected for future usage. It's recommended to conduct tests verifying that the KPI data is accurately recorded and retrieved in the new format, and to confirm that the installation source detection behaves as expected across different installation scenarios.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
