### PR TITLE
Release 1.6.11: version bump + translation changelog entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.6  
 **Requires PHP:** 7.0  
 **Tested up to:** 7.0  
-**Stable tag:** 1.6.10  
+**Stable tag:** 1.6.11  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -162,6 +162,9 @@ You can report the issue through our [Bug Bounty Program](https://brainstormforc
 ---
 
 ## Changelog ##
+### 1.6.11 ###
+* New: UABB Lite now includes translations for 15 additional languages - Indonesian, Brazilian Portuguese, Russian, Italian, Turkish, Japanese, Simplified Chinese, Polish, Arabic, Swedish, Vietnamese, Hebrew, Thai, Greek, and Czech - alongside refreshed Dutch, French, Spanish, and German, expanding multilingual support.
+
 ### 1.6.10 ###
 * Improvement: Optimized codebase and improved code quality.
 

--- a/bb-ultimate-addon.php
+++ b/bb-ultimate-addon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Ultimate Addons for Beaver Builder - Lite
  * Plugin URI: http://www.ultimatebeaver.com/
  * Description: Ultimate Addons is a free extension for Beaver Builder that adds 10 modules, and works on top of any Beaver Builder Package. (Free, Standard, Pro & Agency) You can use it with on any WordPress theme.
- * Version: 1.6.10
+ * Version: 1.6.11
  * Author: Brainstorm Force
  * Author URI: http://www.brainstormforce.com
  * Text Domain: uabb
@@ -18,7 +18,7 @@ if ( ! class_exists( 'BB_Ultimate_Addon' ) ) {
 
 	define( 'BB_ULTIMATE_ADDON_DIR', plugin_dir_path( __FILE__ ) );
 	define( 'BB_ULTIMATE_ADDON_URL', plugins_url( '/', __FILE__ ) );
-	define( 'BB_ULTIMATE_ADDON_LITE_VERSION', '1.6.10' );
+	define( 'BB_ULTIMATE_ADDON_LITE_VERSION', '1.6.11' );
 	define( 'BSF_REMOVE_UABB_FROM_REGISTRATION_LISTING', true );
 	define( 'BB_ULTIMATE_ADDON_FILE', trailingslashit( dirname( __FILE__ ) ) . 'bb-ultimate-addon.php' );// @codingStandardsIgnoreLine.
 	define( 'BB_ULTIMATE_ADDON_LITE', true );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultimate-addons-for-beaver-builder-lite",
-  "version": "1.6.7",
+  "version": "1.6.11",
   "description": "Ultimate Addons is a free extension for Beaver Builder that adds 10 modules, and works on top of any Beaver Builder Package. (Free, Standard, Pro & Agency) You can use it with on any WordPress theme.",
   "main": "Gruntfile.js",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: beaver builder, beaver builder free, beaver builder lite, beaver builder a
 Requires at least: 4.6
 Requires PHP: 7.0
 Tested up to: 7.0
-Stable tag: 1.6.10
+Stable tag: 1.6.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -162,6 +162,9 @@ You can report the issue through our [Bug Bounty Program](https://brainstormforc
 ---
 
 == Changelog ==
+= 1.6.11 =
+* New: UABB Lite now includes translations for 15 additional languages - Indonesian, Brazilian Portuguese, Russian, Italian, Turkish, Japanese, Simplified Chinese, Polish, Arabic, Swedish, Vietnamese, Hebrew, Thai, Greek, and Czech - alongside refreshed Dutch, French, Spanish, and German, expanding multilingual support.
+
 = 1.6.10 =
 * Improvement: Optimized codebase and improved code quality.
 


### PR DESCRIPTION
**Main Purpose**: This pull request updates the version number of the Ultimate Addons for Beaver Builder Lite plugin to 1.6.11, reflecting changes made since the last release, and adds a translation changelog entry.

**Key Changes**:
- Incremented the plugin version from **1.6.10** to **1.6.11** in `bb-ultimate-addon.php`.
- Updated the version number in `package.json` from **1.6.7** to **1.6.11** to maintain consistency across files.
- Included a translation changelog entry for the new version to provide clarity on updates made for localization purposes.

**Additional Notes**: 
- Reviewers should verify that the version bump is correctly reflected across all pertinent files and that any associated changes documented in the translation changelog are accurate. 
- It may be beneficial to check for any potential impact on existing plugin users during the upgrade process, especially in regards to translations or new features introduced in this release.

## Summary
- Bumps version to **1.6.11** across `readme.txt`, `README.md`, and `bb-ultimate-addon.php` (plugin header + `BB_ULTIMATE_ADDON_LITE_VERSION` constant).
- Corrects `package.json` version, which was stale at `1.6.7`, to `1.6.11`.
- Adds the `1.6.11` changelog entry documenting the BSF standard 19-locale translation rollout (15 new languages + 4 refreshed), with formatting/wording aligned to existing entries.

## Test plan
- Verified all four files report `1.6.11` consistently.
- Confirmed all 19 `.po` locales pass the placeholder/format-specifier checks (`grep` detector + `msgfmt --check-format`) — no AI-translation placeholder corruption.
- Verified each language named in the changelog maps to a real `.po` file (15 new + 4 refreshed = 19, matching files on disk).